### PR TITLE
feat: dashboard analytics and interaction telemetry (issue #15)

### DIFF
--- a/apps/web/src/components/charts/PriceLineChart.tsx
+++ b/apps/web/src/components/charts/PriceLineChart.tsx
@@ -23,6 +23,9 @@ export interface ChartReferenceLine {
   stroke?: string;
   strokeDasharray?: string;
   strokeWidth?: number;
+  /** Metadata passed back to onAnnotationClick when the marker is clicked. */
+  id?: string;
+  category?: string;
 }
 
 export interface PriceChartSeries {
@@ -51,6 +54,8 @@ export interface PriceLineChartProps {
     labelFormatter?: (label: any) => string;
   };
   referenceLines?: ChartReferenceLine[];
+  /** Called when an annotation reference line is clicked. */
+  onAnnotationClick?: (ref: ChartReferenceLine) => void;
   className?: string;
 }
 
@@ -74,6 +79,7 @@ export function PriceLineChart({
   margin = { top: 5, right: 30, left: 0, bottom: 5 },
   tooltip,
   referenceLines = [],
+  onAnnotationClick,
   className = '',
 }: PriceLineChartProps) {
   return (
@@ -145,6 +151,8 @@ export function PriceLineChart({
               stroke={ref.stroke ?? '#475569'}
               strokeWidth={ref.strokeWidth ?? 1}
               strokeDasharray={ref.strokeDasharray ?? '3 3'}
+              onClick={onAnnotationClick ? () => onAnnotationClick(ref) : undefined}
+              style={onAnnotationClick ? { cursor: 'pointer' } : undefined}
               label={
                 ref.label
                   ? {

--- a/apps/web/src/hooks/useAnalytics.ts
+++ b/apps/web/src/hooks/useAnalytics.ts
@@ -2,8 +2,9 @@
  * React hooks and helpers for Application Insights analytics.
  *
  * Hooks:
- *  - usePageTracking()  — call once in App.tsx to auto-track route changes
- *  - useTrackEvent()    — returns a stable callback for tracking custom events
+ *  - usePageTracking()        — call once in App.tsx to auto-track route changes
+ *  - useTrackEvent()          — returns a stable callback for tracking custom events
+ *  - useDashboardTelemetry()  — structured callbacks for dashboard interaction events
  *
  * Standalone helpers are also exported from `lib/appInsights.ts` for use
  * in non-hook contexts (e.g. callbacks, class components).
@@ -45,6 +46,107 @@ export function useTrackEvent(category: string) {
     },
     [category],
   );
+}
+
+// ── Dashboard interaction telemetry ─────────────────────────────────────────
+
+/**
+ * Structured analytics callbacks for dashboard interactions.
+ *
+ * Event names are stable string constants so that downstream queries in
+ * Application Insights / Kusto are not affected by UI copy changes.
+ *
+ * @example
+ * const telemetry = useDashboardTelemetry();
+ * telemetry.trackFilterChanged('fuel', 'diesel');
+ * telemetry.trackStateDrilldown('CA');
+ */
+export function useDashboardTelemetry() {
+  /** Fires `dashboard_filter_changed` when any filter is updated. */
+  const trackFilterChanged = useCallback(
+    (filter: string, value: string, previousValue?: string) => {
+      trackEvent('dashboard_filter_changed', {
+        filter,
+        value,
+        ...(previousValue !== undefined ? { previous_value: previousValue } : {}),
+      });
+    },
+    [],
+  );
+
+  /** Fires `time_range_changed` when the chart time range selector changes. */
+  const trackTimeRangeChanged = useCallback(
+    (range: string, previousRange?: string) => {
+      trackEvent('time_range_changed', {
+        range,
+        ...(previousRange !== undefined ? { previous_range: previousRange } : {}),
+      });
+    },
+    [],
+  );
+
+  /** Fires `state_drilldown_opened` when a user clicks a state on the map. */
+  const trackStateDrilldown = useCallback(
+    (stateAbbr: string, fuelType: string) => {
+      trackEvent('state_drilldown_opened', { state: stateAbbr, fuel_type: fuelType });
+    },
+    [],
+  );
+
+  /** Fires `chart_annotation_opened` when a chart annotation marker is clicked. */
+  const trackChartAnnotationOpened = useCallback(
+    (annotationId: string, title: string, category?: string) => {
+      trackEvent('chart_annotation_opened', {
+        annotation_id: annotationId,
+        title,
+        ...(category ? { category } : {}),
+      });
+    },
+    [],
+  );
+
+  /** Fires `story_card_opened` when a market story card is expanded or actioned. */
+  const trackStoryCardOpened = useCallback(
+    (cardId: string, title: string, category: string) => {
+      trackEvent('story_card_opened', { card_id: cardId, title, category });
+    },
+    [],
+  );
+
+  /**
+   * Fires `compare_mode_enabled` when a user activates compare mode.
+   * Payload: the compare target (e.g. a PADD region code or state abbreviation).
+   */
+  const trackCompareModeEnabled = useCallback(
+    (compareTarget: string, fuelType?: string) => {
+      trackEvent('compare_mode_enabled', {
+        compare_target: compareTarget,
+        ...(fuelType ? { fuel_type: fuelType } : {}),
+      });
+    },
+    [],
+  );
+
+  /**
+   * Fires `panel_expanded` when a collapsible dashboard panel is opened.
+   * Payload: a stable panel identifier (e.g. 'supply_health', 'regional_breakdown').
+   */
+  const trackPanelExpanded = useCallback(
+    (panelId: string) => {
+      trackEvent('panel_expanded', { panel_id: panelId });
+    },
+    [],
+  );
+
+  return {
+    trackFilterChanged,
+    trackTimeRangeChanged,
+    trackStateDrilldown,
+    trackChartAnnotationOpened,
+    trackStoryCardOpened,
+    trackCompareModeEnabled,
+    trackPanelExpanded,
+  };
 }
 
 // Re-export primitives so callers only need one import

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import StoryCard from '../components/StoryCard';
 import { usePageSEO } from '../hooks/usePageSEO';
 import { useDashboardFilters } from '../hooks/useDashboardFilters';
 import { useMarketStories } from '../hooks/useMarketStories';
+import { useDashboardTelemetry } from '../hooks/useAnalytics';
 import { resolvePercentChange, toDisplayNumber } from '../lib/priceChange';
 
 const SUPPLY_CLR: Record<string, string> = {
@@ -42,6 +43,7 @@ export default function Dashboard() {
   const navigate = useNavigate();
   const [filters, setFilters] = useDashboardFilters();
   const fuelType = filters.fuel;
+  const telemetry = useDashboardTelemetry();
   const fuelLabel = fuelType === 'gas_regular' ? 'Regular Gasoline' : 'Diesel';
 
   usePageSEO({
@@ -172,7 +174,7 @@ export default function Dashboard() {
         {/* Fuel type toggle */}
         <div className="flex items-center bg-slate-800 rounded-lg border border-slate-700 p-1">
           <button
-            onClick={() => setFilters({ fuel: 'gas_regular' })}
+            onClick={() => { telemetry.trackFilterChanged('fuel', 'gas_regular', fuelType); setFilters({ fuel: 'gas_regular' }); }}
             className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
               fuelType === 'gas_regular'
                 ? 'bg-primary-600 text-white'
@@ -182,7 +184,7 @@ export default function Dashboard() {
             ⛽ Regular Gas
           </button>
           <button
-            onClick={() => setFilters({ fuel: 'diesel' })}
+            onClick={() => { telemetry.trackFilterChanged('fuel', 'diesel', fuelType); setFilters({ fuel: 'diesel' }); }}
             className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-colors ${
               fuelType === 'diesel'
                 ? 'bg-primary-600 text-white'
@@ -203,7 +205,10 @@ export default function Dashboard() {
               <StoryCard
                 key={story.id}
                 {...story}
-                onAction={story.onAction || (() => {})}
+                onAction={() => {
+                  telemetry.trackStoryCardOpened(story.id, story.title, story.category);
+                  story.onAction?.();
+                }}
               />
             ))}
           </div>
@@ -669,7 +674,7 @@ export default function Dashboard() {
       <div className="bg-slate-800 rounded-lg p-6 border border-slate-700 overflow-hidden">
         <h3 className="text-xl font-bold text-white mb-2">Regional Prices</h3>
         <p className="text-xs text-slate-500 mb-4">Click a state for detailed breakdown</p>
-        <USPriceMap comparisonData={comparisonData ?? []} height={380} onStateClick={(abbr) => navigate(`/state/${abbr}${fuelType !== 'gas_regular' ? `?fuel=${fuelType}` : ''}`)} />
+        <USPriceMap comparisonData={comparisonData ?? []} height={380} onStateClick={(abbr) => { telemetry.trackStateDrilldown(abbr, fuelType); navigate(`/state/${abbr}${fuelType !== 'gas_regular' ? `?fuel=${fuelType}` : ''}`); }} />
       </div>
 
       {/* Cost Impact */}

--- a/apps/web/src/pages/Historical.tsx
+++ b/apps/web/src/pages/Historical.tsx
@@ -2,6 +2,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { getAaaNationalHistory, getAaaStateHistory, getAaaPaddHistory, getEvents } from '../api/client';
 import { usePageSEO } from '../hooks/usePageSEO';
+import { useDashboardTelemetry } from '../hooks/useAnalytics';
 import { ChartContainer, PriceLineChart, type PriceChartSeries } from '../components/charts';
 
 type TimeRange = '7D' | '30D' | '90D' | '1Y' | '5Y' | 'ALL';
@@ -106,6 +107,7 @@ export default function Historical() {
   });
 
   const [timeRange, setTimeRange] = useState<TimeRange>('1Y');
+  const telemetry = useDashboardTelemetry();
   const [activeFuels, setActiveFuels] = useState<Set<FuelGrade>>(
     new Set(['regular', 'diesel'])
   );
@@ -323,7 +325,7 @@ export default function Historical() {
             {TIME_RANGES.map((range) => (
               <button
                 key={range.value}
-                onClick={() => setTimeRange(range.value)}
+                onClick={() => { telemetry.trackTimeRangeChanged(range.value, timeRange); setTimeRange(range.value); }}
                 className={`px-3 py-2 rounded-lg font-medium text-sm transition-colors ${
                   timeRange === range.value
                     ? 'bg-blue-600 text-white'
@@ -424,13 +426,20 @@ export default function Historical() {
                     return Math.abs(curTs - eventTs) < Math.abs(bestTs - eventTs) ? cur : best;
                   }, null);
                   return {
+                    id: evt.id ?? String(evt.event_date),
+                    category: evt.category,
                     x: nearest?.time,
-                    label: evt.title.length > 20 ? evt.title.slice(0, 20) + '…' : evt.title,
+                    label: evt.title.length > 20 ? evt.title.slice(0, 20) + '\u2026' : evt.title,
                     stroke: evt.impact === 'bullish' ? '#ef4444' : evt.impact === 'bearish' ? '#22c55e' : '#64748b',
                     strokeWidth: 1,
                     strokeDasharray: '4 2',
                   };
                 }) : []}
+                onAnnotationClick={(ref) => telemetry.trackChartAnnotationOpened(
+                  ref.id ?? ref.x?.toString() ?? 'unknown',
+                  ref.label ?? '',
+                  ref.category,
+                )}
               />
             </ChartContainer>
           </div>

--- a/apps/web/src/test/useAnalytics.test.ts
+++ b/apps/web/src/test/useAnalytics.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock appInsights before importing the hook so trackEvent is intercepted
+vi.mock('../lib/appInsights', () => ({
+  trackEvent: vi.fn(),
+  trackException: vi.fn(),
+  trackPageView: vi.fn(),
+}));
+
+import { trackEvent } from '../lib/appInsights';
+import { useDashboardTelemetry } from '../hooks/useAnalytics';
+
+describe('useDashboardTelemetry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('trackFilterChanged emits dashboard_filter_changed with filter and value', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackFilterChanged('fuel', 'diesel');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('dashboard_filter_changed', {
+      filter: 'fuel',
+      value: 'diesel',
+    });
+  });
+
+  it('trackFilterChanged includes previous_value when provided', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackFilterChanged('fuel', 'diesel', 'gas_regular');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('dashboard_filter_changed', {
+      filter: 'fuel',
+      value: 'diesel',
+      previous_value: 'gas_regular',
+    });
+  });
+
+  it('trackTimeRangeChanged emits time_range_changed with range', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackTimeRangeChanged('3m');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('time_range_changed', { range: '3m' });
+  });
+
+  it('trackTimeRangeChanged includes previous_range when provided', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackTimeRangeChanged('3m', '1m');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('time_range_changed', {
+      range: '3m',
+      previous_range: '1m',
+    });
+  });
+
+  it('trackStateDrilldown emits state_drilldown_opened with state and fuel_type', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackStateDrilldown('CA', 'gas_regular');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('state_drilldown_opened', {
+      state: 'CA',
+      fuel_type: 'gas_regular',
+    });
+  });
+
+  it('trackChartAnnotationOpened emits chart_annotation_opened with id and title', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackChartAnnotationOpened('evt-123', 'OPEC Cut');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('chart_annotation_opened', {
+      annotation_id: 'evt-123',
+      title: 'OPEC Cut',
+    });
+  });
+
+  it('trackChartAnnotationOpened includes category when provided', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackChartAnnotationOpened('evt-123', 'OPEC Cut', 'opec');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('chart_annotation_opened', {
+      annotation_id: 'evt-123',
+      title: 'OPEC Cut',
+      category: 'opec',
+    });
+  });
+
+  it('trackStoryCardOpened emits story_card_opened with id, title, and category', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackStoryCardOpened('story-1', 'OPEC Production Cut', 'event');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('story_card_opened', {
+      card_id: 'story-1',
+      title: 'OPEC Production Cut',
+      category: 'event',
+    });
+  });
+
+  it('trackCompareModeEnabled emits compare_mode_enabled with compare_target', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackCompareModeEnabled('R10');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('compare_mode_enabled', {
+      compare_target: 'R10',
+    });
+  });
+
+  it('trackCompareModeEnabled includes fuel_type when provided', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackCompareModeEnabled('R10', 'diesel');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('compare_mode_enabled', {
+      compare_target: 'R10',
+      fuel_type: 'diesel',
+    });
+  });
+
+  it('trackPanelExpanded emits panel_expanded with panel_id', () => {
+    const { result } = renderHook(() => useDashboardTelemetry());
+    act(() => {
+      result.current.trackPanelExpanded('supply_health');
+    });
+    expect(trackEvent).toHaveBeenCalledWith('panel_expanded', {
+      panel_id: 'supply_health',
+    });
+  });
+
+  it('returns stable callback references across re-renders', () => {
+    const { result, rerender } = renderHook(() => useDashboardTelemetry());
+    const first = result.current.trackFilterChanged;
+    rerender();
+    expect(result.current.trackFilterChanged).toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

Implements structured analytics telemetry for key dashboard interactions as described in issue #15.

## Changes

### `hooks/useAnalytics.ts`
Added `useDashboardTelemetry()` hook with stable callbacks for all instrumented events:

| Callback | Event Name | Description |
|---|---|---|
| `trackFilterChanged` | `dashboard_filter_changed` | Any filter change (fuel type, region, etc.) |
| `trackTimeRangeChanged` | `time_range_changed` | Historical chart time range selector |
| `trackStateDrilldown` | `state_drilldown_opened` | Map state click → state page |
| `trackChartAnnotationOpened` | `chart_annotation_opened` | Event annotation marker click |
| `trackStoryCardOpened` | `story_card_opened` | Market story card actioned |
| `trackCompareModeEnabled` | `compare_mode_enabled` | Compare mode activated (ready for future UI) |
| `trackPanelExpanded` | `panel_expanded` | Collapsible panel opened (ready for future UI) |

### `pages/Dashboard.tsx`
- Fuel type toggle buttons emit `dashboard_filter_changed` with previous value
- Map `onStateClick` emits `state_drilldown_opened` with state abbr + fuel type
- Story card `onAction` emits `story_card_opened` with card id, title, and category

### `pages/Historical.tsx`
- Time range buttons emit `time_range_changed` with previous range
- Chart event reference lines carry `id`/`category` metadata and emit `chart_annotation_opened` on click

### `components/charts/PriceLineChart.tsx`
- Extended `ChartReferenceLine` with `id` and `category` fields
- Added optional `onAnnotationClick` prop to enable clickable annotation markers

### `test/useAnalytics.test.ts`
12 tests covering all event shapes, optional fields, and callback stability.

## Acceptance Criteria
- [x] Key dashboard interactions emit structured analytics events
- [x] Event names and payloads are documented and consistent
- [x] Instrumentation covers public dashboard adoption beyond page views

Closes #15